### PR TITLE
Use an array of structures instead of a structure of arrays for histograms

### DIFF
--- a/benchmarks/bench_histogram.py
+++ b/benchmarks/bench_histogram.py
@@ -17,8 +17,11 @@ def make_data(n_bins=256, n_samples=int(1e8), n_subsample=int(1e6),
     binned_feature = rng.randint(0, n_bins - 1, size=n_samples)
     binned_feature = binned_feature.astype(np.uint8)
 
-    sample_indices = rng.choice(np.arange(n_samples, dtype=np.uint32),
-                                n_subsample, replace=False)
+    if n_subsample is not None and n_subsample < n_samples:
+        sample_indices = rng.choice(np.arange(n_samples, dtype=np.uint32),
+                                    n_subsample, replace=False)
+    else:
+        sample_indices = np.arange(n_samples, dtype=np.uint32)
     return sample_indices, binned_feature, ordered_gradients, ordered_hessians
 
 

--- a/benchmarks/bench_histogram.py
+++ b/benchmarks/bench_histogram.py
@@ -1,7 +1,7 @@
 from time import time
 import numpy as np
 from joblib import Memory
-from pygbm.histogram import build_histogram
+from pygbm.histogram import build_histogram, build_histogram_unrolled
 
 m = Memory(location='/tmp')
 
@@ -28,9 +28,11 @@ sample_indices, binned_feature, gradients, hessians = make_data(
 
 n_subsamples = sample_indices.shape[0]
 n_samples = binned_feature.shape[0]
-print(f"Building feature histogram on {n_subsamples} values of {n_samples}")
-tic = time()
-build_histogram(256, sample_indices, binned_feature, gradients, hessians)
-toc = time()
-duration = toc - tic
-print(f"Built in {duration:.3f}s")
+
+for func in [build_histogram, build_histogram_unrolled]:
+    print(f"{func.__name__} on {n_subsamples:.0e} values of {n_samples:.0e}")
+    tic = time()
+    func(256, sample_indices, binned_feature, gradients, hessians)
+    toc = time()
+    duration = toc - tic
+    print(f"Built in {duration:.3f}s")

--- a/benchmarks/bench_histogram.py
+++ b/benchmarks/bench_histogram.py
@@ -1,7 +1,7 @@
 from time import time
 import numpy as np
 from joblib import Memory
-from pygbm.histogram import Histogram
+from pygbm.histogram import build_histogram
 
 m = Memory(location='/tmp')
 
@@ -30,7 +30,7 @@ n_subsamples = sample_indices.shape[0]
 n_samples = binned_feature.shape[0]
 print(f"Building feature histogram on {n_subsamples} values of {n_samples}")
 tic = time()
-Histogram(n_bins).build(sample_indices, binned_feature, gradients, hessians)
+build_histogram(256, sample_indices, binned_feature, gradients, hessians)
 toc = time()
 duration = toc - tic
 print(f"Built in {duration:.3f}s")

--- a/pygbm/histogram.py
+++ b/pygbm/histogram.py
@@ -9,17 +9,10 @@ HISTOGRAM_DTYPE = np.dtype([
 ])
 
 
+@njit(fastmath=True)
 def build_histogram(n_bins, sample_indices, binned_feature,
                     ordered_gradients, ordered_hessians):
     histogram = np.zeros(n_bins, dtype=HISTOGRAM_DTYPE)
-    _build_histogram(histogram, sample_indices, binned_feature,
-                     ordered_gradients, ordered_hessians)
-    return histogram
-
-
-@njit(fastmath=True)
-def _build_histogram(histogram, sample_indices, binned_feature,
-                     ordered_gradients, ordered_hessians):
     for i, sample_idx in enumerate(sample_indices):
         bin_idx = binned_feature[sample_idx]
         histogram[bin_idx].count += 1

--- a/pygbm/histogram.py
+++ b/pygbm/histogram.py
@@ -15,7 +15,44 @@ def build_histogram(n_bins, sample_indices, binned_feature,
     histogram = np.zeros(n_bins, dtype=HISTOGRAM_DTYPE)
     for i, sample_idx in enumerate(sample_indices):
         bin_idx = binned_feature[sample_idx]
-        histogram[bin_idx].count += 1
         histogram[bin_idx].sum_gradients += ordered_gradients[i]
         histogram[bin_idx].sum_hessians += ordered_hessians[i]
+        histogram[bin_idx].count += 1
+    return histogram
+
+
+@njit(fastmath=True)
+def build_histogram_unrolled(n_bins, sample_indices, binned_feature,
+                             ordered_gradients, ordered_hessians):
+    histogram = np.zeros(n_bins, dtype=HISTOGRAM_DTYPE)
+    n_node_samples = sample_indices.shape[0]
+    unrolled_upper = (n_node_samples // 4) * 4
+
+    for i in range(0, unrolled_upper, 4):
+        bin_0 = binned_feature[sample_indices[i]]
+        bin_1 = binned_feature[sample_indices[i + 1]]
+        bin_2 = binned_feature[sample_indices[i + 2]]
+        bin_3 = binned_feature[sample_indices[i + 3]]
+
+        histogram[bin_0].sum_gradients += ordered_gradients[i]
+        histogram[bin_1].sum_gradients += ordered_gradients[i + 1]
+        histogram[bin_2].sum_gradients += ordered_gradients[i + 2]
+        histogram[bin_3].sum_gradients += ordered_gradients[i + 3]
+
+        histogram[bin_0].sum_hessians += ordered_hessians[i]
+        histogram[bin_1].sum_hessians += ordered_hessians[i + 1]
+        histogram[bin_2].sum_hessians += ordered_hessians[i + 2]
+        histogram[bin_3].sum_hessians += ordered_hessians[i + 3]
+
+        histogram[bin_0].count += 1
+        histogram[bin_1].count += 1
+        histogram[bin_2].count += 1
+        histogram[bin_3].count += 1
+
+    for i in range(unrolled_upper, n_node_samples):
+        bin_idx = binned_feature[sample_indices[i]]
+        histogram[bin_idx].sum_gradients += ordered_gradients[i]
+        histogram[bin_idx].sum_hessians += ordered_hessians[i]
+        histogram[bin_idx].count += 1
+
     return histogram

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -13,6 +13,6 @@ def test_build_histogram():
     ordered_hessians = np.array([1, 1, 2], dtype=np.float32)
     hist = build_histogram(3, sample_indices, binned_features,
                            ordered_gradients, ordered_hessians)
-    assert_array_equal(hist['count'], np.array([2, 1, 0]))
+    assert_array_equal(hist['count'], [2, 1, 0])
     assert_allclose(hist['sum_gradients'], [1, 3, 0])
     assert_allclose(hist['sum_hessians'], [2, 2, 0])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
-from pygbm.histogram import Histogram
+from pygbm.histogram import build_histogram
 
 
 def test_build_histogram():
@@ -11,8 +11,8 @@ def test_build_histogram():
     sample_indices = np.array([0, 2, 3], dtype=np.uint32)
     ordered_gradients = np.array([0, 1, 3], dtype=np.float32)
     ordered_hessians = np.array([1, 1, 2], dtype=np.float32)
-    hist = Histogram(3).build(sample_indices, binned_features,
-                              ordered_gradients, ordered_hessians)
-    assert_array_equal(hist.count, np.array([2, 1, 0]))
-    assert_allclose(hist.sum_gradients, np.array([1, 3, 0], dtype=np.float32))
-    assert_allclose(hist.sum_hessians, np.array([2, 2, 0], dtype=np.float32))
+    hist = build_histogram(3, sample_indices, binned_features,
+                           ordered_gradients, ordered_hessians)
+    assert_array_equal(hist['count'], np.array([2, 1, 0]))
+    assert_allclose(hist['sum_gradients'], [1, 3, 0])
+    assert_allclose(hist['sum_hessians'], [2, 2, 0])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -1,18 +1,33 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
-from pygbm.histogram import build_histogram
+from pygbm.histogram import build_histogram, build_histogram_unrolled
 
 
-def test_build_histogram():
+@pytest.mark.parametrize(
+    'build_func', [build_histogram, build_histogram_unrolled])
+def test_build_histogram(build_func):
     binned_features = np.array(
         [0, 2, 0, 1, 2, 0, 2, 1],
         dtype=np.uint8)
-    sample_indices = np.array([0, 2, 3], dtype=np.uint32)
+
     ordered_gradients = np.array([0, 1, 3], dtype=np.float32)
     ordered_hessians = np.array([1, 1, 2], dtype=np.float32)
-    hist = build_histogram(3, sample_indices, binned_features,
-                           ordered_gradients, ordered_hessians)
+
+    sample_indices = np.array([0, 2, 3], dtype=np.uint32)
+    hist = build_func(3, sample_indices, binned_features,
+                      ordered_gradients, ordered_hessians)
     assert_array_equal(hist['count'], [2, 1, 0])
     assert_allclose(hist['sum_gradients'], [1, 3, 0])
     assert_allclose(hist['sum_hessians'], [2, 2, 0])
+
+    sample_indices = np.array([0, 2, 3, 6, 7], dtype=np.uint32)
+    ordered_gradients = np.array([0, 1, 3, 0, 1], dtype=np.float32)
+    ordered_hessians = np.array([1, 1, 2, 1, 0], dtype=np.float32)
+
+    hist = build_func(3, sample_indices, binned_features,
+                      ordered_gradients, ordered_hessians)
+    assert_array_equal(hist['count'], [2, 2, 1])
+    assert_allclose(hist['sum_gradients'], [1, 4, 0])
+    assert_allclose(hist['sum_hessians'], [2, 2, 1])

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -12,6 +12,7 @@ def test_build_histogram(build_func):
         [0, 2, 0, 1, 2, 0, 2, 1],
         dtype=np.uint8)
 
+    # Small sample_indices (below unrolling threshold)
     ordered_gradients = np.array([0, 1, 3], dtype=np.float32)
     ordered_hessians = np.array([1, 1, 2], dtype=np.float32)
 
@@ -22,6 +23,7 @@ def test_build_histogram(build_func):
     assert_allclose(hist['sum_gradients'], [1, 3, 0])
     assert_allclose(hist['sum_hessians'], [2, 2, 0])
 
+    # Larger sample_indices (above unrolling threshold)
     sample_indices = np.array([0, 2, 3, 6, 7], dtype=np.uint32)
     ordered_gradients = np.array([0, 1, 3, 0, 1], dtype=np.float32)
     ordered_hessians = np.array([1, 1, 2, 1, 0], dtype=np.float32)


### PR DESCRIPTION
On master (structure of arrays using `@njitclass`):

```
$ python benchmarks/bench_histogram.py 
Building feature histogram on 10000000 values of 100000000
Built in 2.007s
```

On this branch / PR (array of structures):

```
$ python benchmarks/bench_histogram.py 
Building feature histogram on 10000000 values of 100000000
Built in 1.655s
```

So the memory access pattern is probably better this way.

Questions for @seibert:

- is there a natural way to use a @jitclass to implement the array of structures pattern.
- when using the `@jitclass` construct, it does not seem to be possible to use `introspect_types` / asm on the instance methods. Is this is a missing feature in the current implementation or is there a fundamental problem that prevents implementing those?