### PR TITLE
[MRG] Update bench_predictor.py and move _get_threads_chunks into utils.py

### DIFF
--- a/benchmarks/bench_predictor.py
+++ b/benchmarks/bench_predictor.py
@@ -1,46 +1,75 @@
 from time import time
+
 import numpy as np
 from numpy.testing import assert_allclose
+from sklearn.datasets import make_regression
 from pygbm.grower import TreeGrower
+from pygbm.binning import BinMapper
+from pygbm.loss import LeastSquares
 
 
 # TODO: make some random numerical data, bin it, and fit a grower with many
 # leaves in a joblib'ed function.
 
+n_samples = int(5e6)
 
-predictor = grower.make_predictor(bin_thresholds=bin_thresholds)
-binned_features_c = np.ascontiguousarray(binned_features)
+X, y = make_regression(n_samples=n_samples, n_features=5)
+bin_mapper = BinMapper()
+X_binned = bin_mapper.fit_transform(X)
+
+loss = LeastSquares()
+gradients, hessians = loss.init_gradients_and_hessians(
+    n_samples, n_trees_per_iteration=1)
+y_pred_init = np.zeros_like(y)
+loss.update_gradients_and_hessians(gradients, hessians, y, y_pred_init)
+
+grower = TreeGrower(X_binned, gradients, hessians, max_leaf_nodes=None)
+grower.grow()
+
+predictor = grower.make_predictor(bin_thresholds=bin_mapper.bin_thresholds_)
+X_binned_c = np.ascontiguousarray(X_binned)
 print("Compiling predictor code...")
 tic = time()
-predictor.predict_binned(np.asfortranarray(binned_features[:10]))
-predictor.predict_binned(binned_features_c[:10])
-predictor.predict(data[:10])
+predictor.predict_binned(np.asfortranarray(X_binned[:100]))
+predictor.predict_binned(X_binned_c[:100])
+predictor.predict(np.asfortranarray(X[:100]))
+predictor.predict(X[:100])
 toc = time()
 print(f"done in {toc - tic:0.3f}s")
 
-data_size = binned_features.nbytes
+data_size = X_binned.nbytes
 print("Computing predictions (F-contiguous binned data)...")
 tic = time()
-scores_binned_f = predictor.predict_binned(binned_features)
+scores_binned_f = predictor.predict_binned(X_binned)
 toc = time()
 duration = toc - tic
-print(f"done in {duration:.3f}s ({data_size / duration / 1e9:.3} GB/s)")
+print(f"done in {duration:.4f}s ({data_size / duration / 1e9:.3} GB/s)")
 
 print("Computing predictions (C-contiguous binned data)...")
 tic = time()
-scores_binned_c = predictor.predict_binned(binned_features_c)
+scores_binned_c = predictor.predict_binned(X_binned_c)
 toc = time()
 duration = toc - tic
-print(f"done in {duration:.3f}s ({data_size / duration / 1e9:.3} GB/s)")
+print(f"done in {duration:.4f}s ({data_size / duration / 1e9:.3} GB/s)")
 
-assert_allclose(scores_binned_f, scores_binned_f)
+assert_allclose(scores_binned_f, scores_binned_c)
+
+data_size = X.nbytes
+print("Computing predictions (F-contiguous numerical data)...")
+tic = time()
+scores_f = predictor.predict(np.asfortranarray(X))
+toc = time()
+duration = toc - tic
+print(f"done in {duration:.4f}s ({data_size / duration / 1e9:.3} GB/s)")
+
+assert_allclose(scores_binned_f, scores_f)
 
 print("Computing predictions (C-contiguous numerical data)...")
-data_size = data.nbytes
+data_size = X.nbytes
 tic = time()
-scores_data = predictor.predict(data)
+scores_c = predictor.predict(X)
 toc = time()
 duration = toc - tic
-print(f"done in {duration:.3f}s ({data_size / duration / 1e9:.3} GB/s)")
+print(f"done in {duration:.4f}s ({data_size / duration / 1e9:.3} GB/s)")
 
-assert_allclose(scores_data, scores_binned_c)
+assert_allclose(scores_binned_f, scores_c)

--- a/pygbm/loss.py
+++ b/pygbm/loss.py
@@ -3,7 +3,8 @@ from abc import ABC, abstractmethod
 from scipy.special import expit, logsumexp
 import numpy as np
 from numba import njit, prange
-import numba
+
+from .utils import _get_threads_chunks
 
 
 # TODO: Write proper docstrings
@@ -20,21 +21,6 @@ def _logsumexp(a):
 
     s = np.sum(np.exp(a - a_max))
     return np.log(s) + a_max
-
-
-@njit
-def _get_threads_chunks(total_size):
-    # Divide [0, total_size - 1] into n_threads contiguous regions, and
-    # returns the starts and ends of each region. Used to simulate a 'static'
-    # scheduling.
-    n_threads = numba.config.NUMBA_DEFAULT_NUM_THREADS
-    sizes = np.full(n_threads, total_size // n_threads, dtype=np.int32)
-    sizes[:total_size % n_threads] += 1
-    starts = np.zeros(n_threads, dtype=np.int32)
-    starts[1:] = np.cumsum(sizes[:-1])
-    ends = starts + sizes
-
-    return starts, ends, n_threads
 
 
 @njit(fastmath=True)

--- a/pygbm/splitting.py
+++ b/pygbm/splitting.py
@@ -2,12 +2,14 @@
 import numpy as np
 from numba import njit, jitclass, prange, float32, uint8, uint32
 import numba
+
 from .histogram import _build_histogram
 from .histogram import _subtract_histograms
 from .histogram import _build_histogram_no_hessian
 from .histogram import _build_histogram_root
 from .histogram import _build_histogram_root_no_hessian
 from .histogram import HISTOGRAM_DTYPE
+from .utils import _get_threads_chunks
 
 
 @jitclass([
@@ -336,25 +338,14 @@ def find_node_split(context, sample_indices):
     #     ctx.ordered_gradients[i] = ctx.gradients[samples_indices[i]]
     # Ordering the gradients and hessians helps to improve cache hit.
     if sample_indices.shape[0] != ctx.gradients.shape[0]:
-        n_threads = numba.config.NUMBA_DEFAULT_NUM_THREADS
-        # Each threads writes data in ordered_xx from starts[thread_idx] to
-        # starts[thread_idx] + sizes[thread_idx]
-        sizes = np.full(n_threads, n_samples // n_threads, dtype=np.int32)
-        if n_samples % n_threads > 0:
-            # array[:0] will cause a bug in numba 0.41 so we need the if.
-            # Remove once issue numba 3554 is fixed.
-            sizes[:n_samples % n_threads] += 1
-        starts = np.zeros(n_threads, dtype=np.int32)
-        starts[1:] = np.cumsum(sizes[:-1])
+        starts, ends, n_threads = _get_threads_chunks(n_samples)
         if ctx.constant_hessian:
             for thread_idx in prange(n_threads):
-                for i in range(starts[thread_idx],
-                               starts[thread_idx] + sizes[thread_idx]):
+                for i in range(starts[thread_idx], ends[thread_idx]):
                     ordered_gradients[i] = ctx.gradients[sample_indices[i]]
         else:
             for thread_idx in prange(n_threads):
-                for i in range(starts[thread_idx],
-                               starts[thread_idx] + sizes[thread_idx]):
+                for i in range(starts[thread_idx], ends[thread_idx]):
                     ordered_gradients[i] = ctx.gradients[sample_indices[i]]
                     ordered_hessians[i] = ctx.hessians[sample_indices[i]]
 


### PR DESCRIPTION
Closes #48 

This PR updates the `bench_predictor` benchmark and moves `_get_threads_chunks` into `utils.py`.

This was initially an attempt to address #48, but it turns out that the results aren't really convincing: computation times with the static scheduling were slightly worse than the current version.
