### PR TITLE
[MRG] Early stopping now done with loss by default

### DIFF
--- a/benchmarks/bench_higgs_boson.py
+++ b/benchmarks/bench_higgs_boson.py
@@ -69,8 +69,9 @@ tic = time()
 pygbm_model = GradientBoostingClassifier(learning_rate=lr, max_iter=1,
                                          max_bins=max_bins,
                                          max_leaf_nodes=n_leaf_nodes,
-                                         random_state=0, scoring=None,
-                                         verbose=0, validation_split=None)
+                                         n_iter_no_change=None,
+                                         random_state=0,
+                                         verbose=0)
 pygbm_model.fit(data_train[:100], target_train[:100])
 pygbm_model.predict(data_train[:100])  # prediction code is also jitted
 toc = time()
@@ -82,8 +83,9 @@ pygbm_model = GradientBoostingClassifier(loss='binary_crossentropy',
                                          learning_rate=lr, max_iter=n_trees,
                                          max_bins=max_bins,
                                          max_leaf_nodes=n_leaf_nodes,
-                                         random_state=0, scoring=None,
-                                         verbose=1, validation_split=None)
+                                         n_iter_no_change=None,
+                                         random_state=0,
+                                         verbose=1)
 pygbm_model.fit(data_train, target_train)
 toc = time()
 predicted_test = pygbm_model.predict(data_test)

--- a/benchmarks/bench_predictor.py
+++ b/benchmarks/bench_predictor.py
@@ -9,8 +9,8 @@ from pygbm import GradientBoostingRegressor
 n_samples = int(5e6)
 
 X, y = make_regression(n_samples=n_samples, n_features=5)
-est = GradientBoostingRegressor(max_iter=1, scoring=None,
-                                validation_split=None, random_state=0)
+est = GradientBoostingRegressor(max_iter=1, n_iter_no_change=None,
+                                random_state=0)
 est.fit(X, y)
 predictor = est.predictors_[0][0]
 

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -16,7 +16,7 @@ X, y = make_regression(n_samples, random_state=rng)
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=rng)
 
 clf = GradientBoostingRegressor(max_iter=10,
-                                scoring=None,
+                                n_iter_no_change=None,
                                 verbose=1,
                                 random_state=rng)
 param_grid = {'learning_rate': [1, .1, .01, .001]}

--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -60,9 +60,9 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         if self.max_iter < 1:
             raise ValueError(f'max_iter={self.max_iter} must '
                              f'not be smaller than 1.')
-        if self.n_iter_no_change < 2:
+        if self.n_iter_no_change is not None and self.n_iter_no_change < 0:
             raise ValueError(f'n_iter_no_change={self.n_iter_no_change} '
-                             f'must not be smaller than 2.')
+                             f'must be positive.')
         if self.validation_split is not None and self.validation_split <= 0:
             raise ValueError(f'validation_split={self.validation_split} '
                              f'must be strictly positive, or None.')
@@ -120,7 +120,10 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
 
         self.loss_ = self._get_loss()
 
-        if self.scoring is not None and self.validation_split is not None:
+        self.do_early_stopping_ = (self.n_iter_no_change is not None and
+                                   self.n_iter_no_change > 0)
+
+        if self.do_early_stopping_ and self.validation_split is not None:
             # stratify for classification
             stratify = y if hasattr(self.loss_, 'predict_proba') else None
 
@@ -143,7 +146,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
             X_binned_val, y_val = None, None
 
         # Subsample the training set for score-based monitoring.
-        if self.scoring is not None:
+        if self.do_early_stopping_:
             subsample_size = 10000
             indices = np.arange(X_binned_train.shape[0])
             if X_binned_train.shape[0] > subsample_size:
@@ -182,15 +185,15 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         # est.predict() or est.predict_proba() depending on its nature.
         self.scorer_ = check_scoring(self, self.scoring)
         self.train_scores_ = []
-        if self.scoring is not None:
+        self.validation_scores_ = []
+        if self.do_early_stopping_:
             # Add predictions of the initial model (before the first tree)
             self.train_scores_.append(
-                self.scorer_(self, X_binned_train, y_train))
+                self._get_scores(X_binned_train, y_train))
 
             if self.validation_split is not None:
-                self.validation_scores_ = []
                 self.validation_scores_.append(
-                    self.scorer_(self, X_binned_val, y_val))
+                    self._get_scores(X_binned_val, y_val))
 
         for iteration in range(self.max_iter):
 
@@ -242,7 +245,8 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                 toc_pred = time()
                 acc_prediction_time += toc_pred - tic_pred
 
-            if self.scoring is not None:
+            should_early_stop = False
+            if self.do_early_stopping_:
                 should_early_stop = self._check_early_stopping(
                     X_binned_small_train, y_small_train,
                     X_binned_val, y_val)
@@ -250,7 +254,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
             if self.verbose:
                 self._print_iteration_stats(iteration_start_time)
 
-            if self.scoring is not None and should_early_stop:
+            if should_early_stop:
                 break
 
         if self.verbose:
@@ -272,8 +276,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                   f"{acc_prediction_time:.3f}s")
 
         self.train_scores_ = np.asarray(self.train_scores_)
-        if self.scoring is not None and self.validation_split is not None:
-            self.validation_scores_ = np.asarray(self.validation_scores_)
+        self.validation_scores_ = np.asarray(self.validation_scores_)
         return self
 
     def _check_early_stopping(self, X_binned_train, y_train,
@@ -283,11 +286,12 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         Scores are computed on validation data or on training data.
         """
 
-        self.train_scores_.append(self.scorer_(self, X_binned_train, y_train))
+        self.train_scores_.append(
+            self._get_scores(X_binned_train, y_train))
 
         if self.validation_split is not None:
             self.validation_scores_.append(
-                self.scorer_(self, X_binned_val, y_val))
+                self._get_scores(X_binned_val, y_val))
             return self._should_stop(self.validation_scores_)
 
         return self._should_stop(self.train_scores_)
@@ -312,6 +316,20 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                                for score in recent_scores]
         return not any(recent_improvements)
 
+    def _get_scores(self, X, y):
+        """Compute scores on data X with target y.
+
+        Scores are either computed with a scorer if scoring parameter is not
+        None, else with the loss. As higher is always better, we return
+        -loss_value.
+        """
+        if self.scoring is not None:
+            return self.scorer_(self, X, y)
+
+        # Else, use loss
+        raw_predictions = self._raw_predict(X)
+        return -self.loss_(y, raw_predictions)
+
     def _print_iteration_stats(self, iteration_start_time):
         """Print info about the current fitting iteration."""
         log_msg = ''
@@ -334,7 +352,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
 
         log_msg += f"max depth = {max_depth}, "
 
-        if self.scoring is not None:
+        if self.do_early_stopping_:
             log_msg += f"{self.scoring} train: {self.train_scores_[-1]:.5f}, "
             if self.validation_split is not None:
                 log_msg += (f"{self.scoring} val: "
@@ -427,18 +445,19 @@ class GradientBoostingRegressor(BaseGradientBoostingMachine, RegressorMixin):
         number of unique values may use less than ``max_bins`` bins. Must be no
         larger than 256.
     scoring : str or callable or None, \
-        optional (default='neg_mean_squared_error')
+        optional (default=None)
         Scoring parameter to use for early stopping (see sklearn.metrics for
-        available options). If None, no early stopping is done.
+        available options). If None, early stopping is check w.r.t the loss
+        value.
     validation_split : int or float or None, optional(default=0.1)
         Proportion (or absolute size) of training data to set aside as
         validation data for early stopping. If None, early stopping is done on
-        the whole training data.
-    n_iter_no_change : int, optional (default=5)
+        the training data.
+    n_iter_no_change : int or None, optional (default=5)
         Used to determine when to "early stop". The fitting process is
         stopped when none of the last ``n_iter_no_change`` scores are better
         than the ``n_iter_no_change - 1``th-to-last one, up to some
-        tolerance.
+        tolerance. If None or 0, no early-stopping is done.
     tol : float or None optional (default=1e-7)
         The absolute tolerance to use when comparing scores. The higher the
         tolerance, the more likely we are to early stop: higher tolerance
@@ -468,11 +487,11 @@ class GradientBoostingRegressor(BaseGradientBoostingMachine, RegressorMixin):
 
     _VALID_LOSSES = ('least_squares',)
 
-    def __init__(self, loss='least_squares', learning_rate=0.1, max_iter=100,
-                 max_leaf_nodes=31, max_depth=None, min_samples_leaf=20,
-                 l2_regularization=0., max_bins=256,
-                 scoring='neg_mean_squared_error', validation_split=0.1,
-                 n_iter_no_change=5, tol=1e-7, verbose=0, random_state=None):
+    def __init__(self, loss='least_squares', learning_rate=0.1,
+                 max_iter=100, max_leaf_nodes=31, max_depth=None,
+                 min_samples_leaf=20, l2_regularization=0., max_bins=256,
+                 scoring=None, validation_split=0.1, n_iter_no_change=5,
+                 tol=1e-7, verbose=0, random_state=None):
         super(GradientBoostingRegressor, self).__init__(
             loss=loss, learning_rate=learning_rate, max_iter=max_iter,
             max_leaf_nodes=max_leaf_nodes, max_depth=max_depth,
@@ -546,18 +565,19 @@ class GradientBoostingClassifier(BaseGradientBoostingMachine, ClassifierMixin):
         allows for a much faster training stage. Features with a small
         number of unique values may use less than ``max_bins`` bins. Must be no
         larger than 256.
-    scoring : str or callable or None, optional (default='accuracy')
+    scoring : str or callable or None, optional (default=None)
         Scoring parameter to use for early stopping (see sklearn.metrics for
-        available options). If None, no early stopping is done.
+        available options). If None, early stopping is check w.r.t the loss
+        value.
     validation_split : int or float or None, optional(default=0.1)
         Proportion (or absolute size) of training data to set aside as
         validation data for early stopping. If None, early stopping is done on
-        the whole training data.
-    n_iter_no_change : int, optional (default=5)
+        the training data.
+    n_iter_no_change : int or None, optional (default=5)
         Used to determine when to "early stop". The fitting process is
         stopped when none of the last ``n_iter_no_change`` scores are better
         than the ``n_iter_no_change - 1``th-to-last one, up to some
-        tolerance.
+        tolerance. If None or 0, no early-stopping is done.
     tol : float or None optional (default=1e-7)
         The absolute tolerance to use when comparing scores. The higher the
         tolerance, the more likely we are to early stop: higher tolerance
@@ -588,7 +608,7 @@ class GradientBoostingClassifier(BaseGradientBoostingMachine, ClassifierMixin):
 
     def __init__(self, loss='auto', learning_rate=0.1, max_iter=100,
                  max_leaf_nodes=31, max_depth=None, min_samples_leaf=20,
-                 l2_regularization=0., max_bins=256, scoring='neg_log_loss',
+                 l2_regularization=0., max_bins=256, scoring=None,
                  validation_split=0.1, n_iter_no_change=5, tol=1e-7,
                  verbose=0, random_state=None):
         super(GradientBoostingClassifier, self).__init__(

--- a/pygbm/loss.py
+++ b/pygbm/loss.py
@@ -239,8 +239,9 @@ class CategoricalCrossEntropy(BaseLoss):
         for k in range(prediction_dim):
             one_hot_true[:, k] = (y_true == k)
 
-        return (logsumexp(raw_predictions, axis=1) -
+        loss = (logsumexp(raw_predictions, axis=1) -
                 (one_hot_true * raw_predictions).sum(axis=1))
+        return loss.mean() if average else loss
 
     def get_baseline_prediction(self, y_train, prediction_dim):
         init_value = np.zeros(

--- a/pygbm/utils.py
+++ b/pygbm/utils.py
@@ -21,7 +21,7 @@ def get_lightgbm_estimator(pygbm_estimator):
     if pygbm_params['loss'] == 'auto':
         raise ValueError('auto loss is not accepted. We need to know if '
                          'the problem is binary or multiclass classification.')
-    if pygbm_params['scoring'] is not None:
+    if pygbm_params['n_iter_no_change'] is not None:
         raise NotImplementedError('Early stopping should be deactivated.')
 
     loss_mapping = {

--- a/tests/test_compare_lightgbm.py
+++ b/tests/test_compare_lightgbm.py
@@ -52,7 +52,7 @@ def test_same_predictions_regression(seed, min_samples_leaf, n_samples,
     est_pygbm = GradientBoostingRegressor(max_iter=max_iter,
                                           max_bins=max_bins,
                                           learning_rate=1,
-                                          validation_split=None, scoring=None,
+                                          n_iter_no_change=None,
                                           min_samples_leaf=min_samples_leaf,
                                           max_leaf_nodes=max_leaf_nodes)
     est_lightgbm = get_lightgbm_estimator(est_pygbm)
@@ -102,8 +102,7 @@ def test_same_predictions_classification(seed, min_samples_leaf, n_samples,
                                            max_iter=max_iter,
                                            max_bins=max_bins,
                                            learning_rate=1,
-                                           validation_split=None,
-                                           scoring=None,
+                                           n_iter_no_change=None,
                                            min_samples_leaf=min_samples_leaf,
                                            max_leaf_nodes=max_leaf_nodes)
     est_lightgbm = get_lightgbm_estimator(est_pygbm)
@@ -162,8 +161,7 @@ def test_same_predictions_multiclass_classification(
                                            max_iter=max_iter,
                                            max_bins=max_bins,
                                            learning_rate=lr,
-                                           validation_split=None,
-                                           scoring=None,
+                                           n_iter_no_change=None,
                                            min_samples_leaf=min_samples_leaf,
                                            max_leaf_nodes=max_leaf_nodes)
     est_lightgbm = get_lightgbm_estimator(est_pygbm)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -49,7 +49,8 @@ def test_plot_estimator_and_lightgbm(tmpdir):
                                random_state=0)
 
     n_trees = 3
-    est_pygbm = GradientBoostingClassifier(max_iter=n_trees, scoring=None)
+    est_pygbm = GradientBoostingClassifier(max_iter=n_trees,
+                                           n_iter_no_change=None)
     est_pygbm.fit(X, y)
     est_lightgbm = lightgbm.LGBMClassifier(n_estimators=n_trees)
     est_lightgbm.fit(X, y)


### PR DESCRIPTION
Closes #69 

Changes:

- early stopping is done iff `n_iter_no_change is not None and n_iter_no_change > 0`
- If early stopping is done:
   - Use loss iff `scoring` is None (default)
   - Use validation data iff `validation_split` is not None

There are 4 early stopping scenarios: training data and scorer, training data and loss, validation data and scorer, validation data and loss.

For furture improvements:
If early stopping is done on training data and loss, compute loss in `_update_gradients_and_hessians` to avoid multiple computations. That would also require a bit a refactoring because for now the training loss / scores are computed on the subsampled `X_binned_small` data, not on the whole data.