### PR TITLE
More memory friendly

### DIFF
--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -148,11 +148,14 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         # Subsample the training set for score-based monitoring.
         if do_early_stopping:
             subsample_size = 10000
-            indices = np.arange(X_binned_train.shape[0])
-            if X_binned_train.shape[0] > subsample_size:
-                indices = rng.choice(indices, subsample_size)
-            X_binned_small_train = X_binned_train[indices]
-            y_small_train = y_train[indices]
+            n_samples_train = X_binned_train.shape[0]
+            if n_samples_train > subsample_size:
+                indices = rng.choice(X_binned_train.shape[0], subsample_size)
+                X_binned_small_train = X_binned_train[indices]
+                y_small_train = y_train[indices]
+            else:
+                X_binned_small_train = X_binned_train
+                y_small_train = y_train
             # Predicting is faster of C-contiguous arrays.
             X_binned_small_train = np.ascontiguousarray(X_binned_small_train)
 


### PR DESCRIPTION
again, great project!

I'm trying to push pygbm to its limits (10^9 samples), and there are two places that can be a bit more memory friendly:
 * instead of calling choise with the full samples, and then reducing, just ask what is needed
 * the tree grower memory will only be released if the new instance is created, this causes a memory spike / some stress. Better is to enable Python to release it before the new memory is allocated. I also force gc.collect to make sure it did. (if you agree, I'll put the import toplevel)

I also that splitting.py is quite memory hungry, can this be improved? Can we not copy the gradient? It looks to me that a full copy is not needed, but you probably have more insight into this, I also wonder if partition / left_indices_buffer / right_indices_buffer can be non-full length. But i'm still digesting this piece of code.