### PR TITLE
Failed attempt at ordered gradients/hessians

### DIFF
--- a/benchmarks/bench_higgs_boson.py
+++ b/benchmarks/bench_higgs_boson.py
@@ -85,7 +85,7 @@ pygbm_model = GradientBoostingClassifier(loss='binary_crossentropy',
                                          max_leaf_nodes=n_leaf_nodes,
                                          n_iter_no_change=None,
                                          random_state=0,
-                                         verbose=1)
+                                         verbose=1, parallel_splitting=False)
 pygbm_model.fit(data_train, target_train)
 toc = time()
 predicted_test = pygbm_model.predict(data_test)

--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -148,11 +148,14 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         # Subsample the training set for score-based monitoring.
         if do_early_stopping:
             subsample_size = 10000
-            indices = np.arange(X_binned_train.shape[0])
-            if X_binned_train.shape[0] > subsample_size:
-                indices = rng.choice(indices, subsample_size)
-            X_binned_small_train = X_binned_train[indices]
-            y_small_train = y_train[indices]
+            n_samples_train = X_binned_train.shape[0]
+            if n_samples_train > subsample_size:
+                indices = rng.choice(X_binned_train.shape[0], subsample_size)
+                X_binned_small_train = X_binned_train[indices]
+                y_small_train = y_train[indices]
+            else:
+                X_binned_small_train = X_binned_train
+                y_small_train = y_train
             # Predicting is faster of C-contiguous arrays.
             X_binned_small_train = np.ascontiguousarray(X_binned_small_train)
 

--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -222,7 +222,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                 # whole array.
 
                 grower = TreeGrower(
-                    X_binned_train, gradients_at_k, hessians_at_k,
+                    X_binned_train, gradients_at_k.copy(), hessians_at_k,
                     max_bins=self.max_bins,
                     n_bins_per_feature=self.bin_mapper_.n_bins_per_feature_,
                     max_leaf_nodes=self.max_leaf_nodes,

--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -26,7 +26,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
     def __init__(self, loss, learning_rate, max_iter, max_leaf_nodes,
                  max_depth, min_samples_leaf, l2_regularization, max_bins,
                  scoring, validation_split, n_iter_no_change, tol, verbose,
-                 random_state):
+                 random_state, parallel_splitting):
         self.loss = loss
         self.learning_rate = learning_rate
         self.max_iter = max_iter
@@ -41,6 +41,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
         self.tol = tol
         self.verbose = verbose
         self.random_state = random_state
+        self.parallel_splitting = parallel_splitting
 
     def _validate_parameters(self):
         """Validate parameters passed to __init__.
@@ -228,7 +229,8 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                     max_depth=self.max_depth,
                     min_samples_leaf=self.min_samples_leaf,
                     l2_regularization=self.l2_regularization,
-                    shrinkage=self.learning_rate)
+                    shrinkage=self.learning_rate,
+                    parallel_splitting=self.parallel_splitting)
                 grower.grow()
 
                 acc_apply_split_time += grower.total_apply_split_time
@@ -495,7 +497,8 @@ class GradientBoostingRegressor(BaseGradientBoostingMachine, RegressorMixin):
                  max_iter=100, max_leaf_nodes=31, max_depth=None,
                  min_samples_leaf=20, l2_regularization=0., max_bins=256,
                  scoring=None, validation_split=0.1, n_iter_no_change=5,
-                 tol=1e-7, verbose=0, random_state=None):
+                 tol=1e-7, verbose=0, random_state=None,
+                 parallel_splitting=True):
         super(GradientBoostingRegressor, self).__init__(
             loss=loss, learning_rate=learning_rate, max_iter=max_iter,
             max_leaf_nodes=max_leaf_nodes, max_depth=max_depth,
@@ -503,7 +506,7 @@ class GradientBoostingRegressor(BaseGradientBoostingMachine, RegressorMixin):
             l2_regularization=l2_regularization, max_bins=max_bins,
             scoring=scoring, validation_split=validation_split,
             n_iter_no_change=n_iter_no_change, tol=tol, verbose=verbose,
-            random_state=random_state)
+            random_state=random_state, parallel_splitting=parallel_splitting)
 
     def predict(self, X):
         """Predict values for X.
@@ -614,7 +617,7 @@ class GradientBoostingClassifier(BaseGradientBoostingMachine, ClassifierMixin):
                  max_leaf_nodes=31, max_depth=None, min_samples_leaf=20,
                  l2_regularization=0., max_bins=256, scoring=None,
                  validation_split=0.1, n_iter_no_change=5, tol=1e-7,
-                 verbose=0, random_state=None):
+                 verbose=0, random_state=None, parallel_splitting=True):
         super(GradientBoostingClassifier, self).__init__(
             loss=loss, learning_rate=learning_rate, max_iter=max_iter,
             max_leaf_nodes=max_leaf_nodes, max_depth=max_depth,
@@ -622,7 +625,7 @@ class GradientBoostingClassifier(BaseGradientBoostingMachine, ClassifierMixin):
             l2_regularization=l2_regularization, max_bins=max_bins,
             scoring=scoring, validation_split=validation_split,
             n_iter_no_change=n_iter_no_change, tol=tol, verbose=verbose,
-            random_state=random_state)
+            random_state=random_state, parallel_splitting=parallel_splitting)
 
     def predict(self, X):
         """Predict classes for X.

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -43,7 +43,7 @@ def test_histogram_split(n_bins):
                                        True)
 
             split_info, _ = _find_histogram_split(context, feature_idx,
-                                                  sample_indices)
+                                                  sample_indices, all_gradients)
 
             assert split_info.bin_idx == true_bin
             assert split_info.gain >= 0
@@ -92,10 +92,18 @@ def test_split_vs_split_subtraction(constant_hessian):
     sample_indices_left = sample_indices[mask]
     sample_indices_right = sample_indices[~mask]
 
+    gradient_left = all_gradients[sample_indices_left]
+    gradient_right = all_gradients[sample_indices_right]
+    if constant_hessian:
+        hessians_left = hessians_right = all_hessians
+    else:
+        hessians_left = all_hessians[sample_indices_left]
+        hessians_right = all_hessians[sample_indices_right]
+
     # first split parent, left and right with classical method
-    si_parent, hists_parent = find_node_split(context, sample_indices)
-    si_left, hists_left = find_node_split(context, sample_indices_left)
-    si_right, hists_right = find_node_split(context, sample_indices_right)
+    si_parent, hists_parent = find_node_split(context, sample_indices, all_gradients, all_hessians)
+    si_left, hists_left = find_node_split(context, sample_indices_left, gradient_left, hessians_left)
+    si_right, hists_right = find_node_split(context, sample_indices_right, gradient_right, hessians_right)
 
     # split left with subtraction method
     si_left_sub, hists_left_sub = find_node_split_subtraction(


### PR DESCRIPTION
I'm giving up on the idea, but pushing this anyway in case someone comes up with the same idea.

My idea was, that if the hessians and gradients followed the same order of partition, it would be more cache (or even disk swap) friendly, since it will lead to less random access. The current code only works for parallel_splitting=False, but does not seem to have better performance. The parallel_splitting=True path is half implemented, it still has a bug, but it already shows no performance boost.

I think it also means that implementing #84 will not give a performance boost, only use less memory.