### PR TITLE
[MRG] Reuse grower and splitter memory

### DIFF
--- a/benchmarks/bench_higgs_boson.py
+++ b/benchmarks/bench_higgs_boson.py
@@ -86,7 +86,10 @@ pygbm_model = GradientBoostingClassifier(loss='binary_crossentropy',
                                          n_iter_no_change=None,
                                          random_state=0,
                                          verbose=1)
-pygbm_model.fit(data_train, target_train)
+@profile
+def fit():
+    pygbm_model.fit(data_train, target_train)
+fit()
 toc = time()
 predicted_test = pygbm_model.predict(data_test)
 roc_auc = roc_auc_score(target_test, predicted_test)

--- a/pygbm/gradient_boosting.py
+++ b/pygbm/gradient_boosting.py
@@ -228,6 +228,17 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                                                      y_train, raw_predictions)
 
             predictors.append([])
+            grower = TreeGrower(
+                X_binned_train,
+                max_bins=self.max_bins,
+                n_bins_per_feature=n_bins_per_feature,
+                max_leaf_nodes=self.max_leaf_nodes,
+                max_depth=self.max_depth,
+                min_samples_leaf=self.min_samples_leaf,
+                l2_regularization=self.l2_regularization,
+                shrinkage=self.learning_rate,
+                hessian_is_constant=self.loss_.hessian_is_constant
+            )
 
             # Build `n_trees_per_iteration` trees.
             for k, (gradients_at_k, hessians_at_k) in enumerate(zip(
@@ -238,15 +249,7 @@ class BaseGradientBoostingMachine(BaseEstimator, ABC):
                 # n_trees_per_iteration is 1 and xxxx_at_k is equivalent to the
                 # whole array.
 
-                grower = TreeGrower(
-                    X_binned_train, gradients_at_k, hessians_at_k,
-                    max_bins=self.max_bins,
-                    n_bins_per_feature=n_bins_per_feature,
-                    max_leaf_nodes=self.max_leaf_nodes,
-                    max_depth=self.max_depth,
-                    min_samples_leaf=self.min_samples_leaf,
-                    l2_regularization=self.l2_regularization,
-                    shrinkage=self.learning_rate)
+                grower.reset(gradients_at_k, hessians_at_k)
                 grower.grow()
 
                 acc_apply_split_time += grower.total_apply_split_time


### PR DESCRIPTION
Closes #81 

Instead of creating a new grower and a new splitter for every tree, we reuse the existing objects and thus the allocated arrays (`ordered_gradients`, `partition`, etc.)

I didn't observe any significant speed improvement with:

```
benchmarks/bench_higgs_boson.py --no-lightgbm  --n-trees 100  --subsample 1000000
```

but that might come with parallelization.

I haven't run any memory usage benchmark, I'm not sure if `memory_profiler` is really suited for this.

@ogrisel if you're OK with this in general I'll fix the tests (`compare_lightgbm` is already passing) and I will parallelize `SplittingContext.reset()`.